### PR TITLE
skip empty files

### DIFF
--- a/04_metric_collector.Rmd
+++ b/04_metric_collector.Rmd
@@ -71,10 +71,14 @@ d <- list()
 metrics_files <- read.table(args$input_files_mapping, header = FALSE)$V1
 
 for (fn in metrics_files){
-    d[[fn]] <- list(
-        run = read_params(out = args$wd, file_path = fn),    
-        metrics = read.csv(fn, header = TRUE)
-    )
+    if (file.size(fn) > 0) {
+        d[[fn]] <- list(
+            run = read_params(out = args$wd, file_path = fn),
+            metrics = read.csv(fn, header = TRUE)
+        )
+    } else {
+        message(sprintf("Skipping empty file: %s", fn))
+    }
 }
 ```
 


### PR DESCRIPTION
the metric collector should gracefully handle empty files.
this is a consequence of me switching to a touch strategy to be able to make the metric collector run even if intermediate jobs fail.